### PR TITLE
DB user password not needed by default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,26 @@ cd /path/to/daedalus
 ./aircra.sh -d mysql_dbname -u mysql_dbuser
 ```
 
+If the MySQL user requires a password, then add the `-p` option to the aircra.sh command.
+
+```bash
+cd /path/to/daedalus
+./aircra.sh -d mysql_dbname -u mysql_dbuser -p
+```
+
+You will be prompted for the password of the MySQL user. Once entered, the remainder of the scripts will run, and you will finish with a csv export of the General Aviation accident dataset in the Daedalus project directory.
+
 All the options available to you when running the shell script `aircra.sh` are:
 
 ```
 -d (required): mysql database name that must be created before running command.
 -u (required): mysql user that must have all privileges for database.
--p (optional): Add this option if password is required for the mysql user. This option does not accept arguments. By default, aircra.sh does not expect a password for your mysql user.
--h (optional): database host name. Default value is 'localhost'.
+-p (optional): add this option if password is required for the mysql user. This option does not accept arguments. By default, aircra.sh does not expect a password for your mysql user.
+-n (optional): database host name. Default value is 'localhost'.
+-h (optional): show instructions for using aircra.sh script.
 ```
 
-You will be prompted for the password of the MySQL user. Once entered, the remainder of the scripts will run, and you will finish with a csv export of the General Aviation accident dataset in the Daedalus project directory.
-
-**Note:** The `aircra.sh` shell script also accepts option `-h` for defining the database host. That option defaults to `localhost`, but you are free to override that value if necessary.
+**Note:** The `aircra.sh` shell script also accepts option `-n` for defining the database host. That option defaults to `localhost`, but you are free to override that value if necessary.
 
 ### System Requirements
 The current version of this repository consists simply of csv data sheets, a shell script, and sql scripts that handle importing, merging, and exporting a dataset on General Aviation accident data. Thus, you only need a utility like Terminal to run the shell script and MySQL to handle the data conversion.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd /path/to/daedalus
 ./aircra.sh -d mysql_dbname -u mysql_dbuser
 ```
 
-If the MySQL user requires a password, then add the `-p` option to the aircra.sh command.
+If the MySQL user requires a password, then add the `-p` option to the `aircra.sh` command.
 
 ```bash
 cd /path/to/daedalus

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Create a MySQL database of any name of your choosing, and a database user with a
 
 ```bash
 cd /path/to/daedalus
-./aircra.sh -u mysql_dbuser -d mysql_dbname
+./aircra.sh -d mysql_dbname -u mysql_dbuser
 ```
 
 All the options available to you when running the shell script `aircra.sh` are:
 
 ```
 -d (required): mysql database name that must be created before running command.
--u (required): mysql user that must have all privileges for database specified in option -d.
+-u (required): mysql user that must have all privileges for database.
+-p (optional): Add this option if password is required for the mysql user. This option does not accept arguments. By default, aircra.sh does not expect a password for your mysql user.
 -h (optional): database host name. Default value is 'localhost'.
--p (optional): Set this option to FALSE or F if password is not required for the mysql user. By default, aircra.sh expects a password for your mysql user.
 ```
 
 You will be prompted for the password of the MySQL user. Once entered, the remainder of the scripts will run, and you will finish with a csv export of the General Aviation accident dataset in the Daedalus project directory.

--- a/aircra.sh
+++ b/aircra.sh
@@ -10,34 +10,45 @@ Options:
 -n (optional): database host name. Default value is \'localhost\'.
 -h (optional): show instructions for using aircra.sh script.'
 
-while getopts ":d:u:pn:h" option
+while [[ $# -gt 0 ]]
 do
-  case "${option}" in
-    d)
-      DATABASE=${OPTARG}
-      ;;
-    u)
-      DBUSER=${OPTARG}
-      ;;
-    p)
-      PASS="TRUE"
-      ;;
-    n)
-      DBHOST=${OPTARG}
-      ;;
-    h)
-      echo "$USAGE" >&2
-      exit 1
-      ;;
-    \?)
-      echo "$USAGE" >&2
-      exit 1
-      ;;
-    :) 
-      echo "$USAGE" >&2
-      exit 1
-      ;;
-  esac
+  unset OPTIND
+  unset OPTARG
+
+  while getopts ":d:u:pn:h" option
+  do
+    case "${option}" in
+      d)
+        DATABASE=${OPTARG}
+        ;;
+      u)
+        DBUSER=${OPTARG}
+        ;;
+      p)
+        PASS="TRUE"
+        ;;
+      n)
+        DBHOST=${OPTARG}
+        ;;
+      h)
+        echo "$USAGE" >&2
+        exit 1
+        ;;
+      \?)
+        echo "Error: Invalid option -$OPTARG specified" >&2
+        echo "$USAGE" >&2
+        exit 1
+        ;;
+      :)
+        echo "Error: Option -$OPTARG requires an argument" >&2
+        echo "$USAGE" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  shift "$((OPTIND - 1))"
+  shift
 done
 
 MYSQL=$(which mysql)
@@ -49,7 +60,8 @@ then
 else
   if [[ -z "$DBUSER" || -z "$DATABASE" ]]
   then
-    echo "$USAGE"
+    echo "Error: Database or User have not been defined" >&2
+    echo "$USAGE" >&2
     exit 1
   else
     echo 'Copying csv data to tmp folder to prepare for MySQL import.'

--- a/aircra.sh
+++ b/aircra.sh
@@ -1,28 +1,33 @@
 #!/bin/bash
 
 DBHOST="localhost"
-USAGE=$'Usage: ./aircra.sh -d database -u username -p -h localhost
+USAGE=$'Usage: ./aircra.sh -d database -u username -p -n localhost
 
 Options:
 -d (required): mysql database name that must be created before running command.
 -u (required): mysql user that must have all privileges for database.
--p (optional): Add this option if password is required for the mysql user. This option does not accept arguments. By default, aircra.sh does not expect a password for your mysql user.
--h (optional): database host name. Default value is \'localhost\'.'
+-p (optional): add this option if password is required for the mysql user. This option does not accept arguments. By default, aircra.sh does not expect a password for your mysql user.
+-n (optional): database host name. Default value is \'localhost\'.
+-h (optional): show instructions for using aircra.sh script.'
 
-while getopts ":d:u:ph:" option
+while getopts ":d:u:pn:h" option
 do
   case "${option}" in
-    u) 
-      DBUSER=${OPTARG}
-      ;;
     d)
       DATABASE=${OPTARG}
+      ;;
+    u)
+      DBUSER=${OPTARG}
       ;;
     p)
       PASS="TRUE"
       ;;
-    h) 
+    n)
       DBHOST=${OPTARG}
+      ;;
+    h)
+      echo "$USAGE" >&2
+      exit 1
       ;;
     \?)
       echo "$USAGE" >&2


### PR DESCRIPTION
When executing `aircra.sh`, do not prompt user for MySQL password unless `-p` option is defined. Added help option `-h` and cleaned up error messages and documentation accordingly. Fixes issue #13.